### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-docker-image.yml
+++ b/.github/workflows/dev-docker-image.yml
@@ -5,7 +5,10 @@ on:
     types: [prereleased]
     branches:    
       - next
-    
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/versun/RSS-Translator/security/code-scanning/14](https://github.com/versun/RSS-Translator/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily interacts with repository contents (e.g., fetching tags and branches), so `contents: read` is sufficient. If additional permissions are required in the future, they can be added explicitly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
