### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -1,5 +1,9 @@
 name: latest:Docker Image CI
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   release:
     types: [released]


### PR DESCRIPTION
Potential fix for [https://github.com/versun/RSS-Translator/security/code-scanning/13](https://github.com/versun/RSS-Translator/security/code-scanning/13)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimum permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for `actions/checkout` to fetch the repository's code.
- `packages: write` is required for `docker/login-action` and `docker/build-push-action` to authenticate and push Docker images.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
