### PR TITLE
[Bug] Fix Docker build/runtime issues on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+Dockerfile text eol=lf
+config/rt_cron text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,8 @@ RUN mkdir -p /var/run/cron && \
     chmod 644 /var/run/crond.pid 
 
 COPY config/rt_cron /etc/cron.d/rt_cron
-RUN chmod 0644 /etc/cron.d/rt_cron && \
+RUN sed -i 's/\r$//' /etc/cron.d/rt_cron && \
+    chmod 0644 /etc/cron.d/rt_cron && \
     touch /var/log/cron.log
 
 # 设置entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,12 +64,12 @@ RUN mkdir -p /var/run/cron && \
 
 COPY config/rt_cron /etc/cron.d/rt_cron
 RUN chmod 0644 /etc/cron.d/rt_cron && \
-    crontab /etc/cron.d/rt_cron && \
     touch /var/log/cron.log
 
 # 设置entrypoint
 COPY scripts/entrypoint.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN sed -i 's/\r$//' /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
     
 # 声明端口
 EXPOSE ${PORT}

--- a/config/rt_cron
+++ b/config/rt_cron
@@ -5,7 +5,7 @@
 # 每30分钟执行一次 feed_updater_for_frequency 任务
 */30 * * * * root cd /app && /opt/venv/bin/python manage.py feed_updater --frequency '30 min' >> /var/log/cron.log 2>&1
 # 每60分钟执行一次 feed_updater_for_frequency 任务
-*/60 * * * * root cd /app && /opt/venv/bin/python manage.py feed_updater --frequency 'hourly' >> /var/log/cron.log 2>&1
+0 * * * * root cd /app && /opt/venv/bin/python manage.py feed_updater --frequency 'hourly' >> /var/log/cron.log 2>&1
 # 每天凌晨1点执行一次 feed_updater_for_frequency 任务
 0 1 * * * root cd /app && /opt/venv/bin/python manage.py feed_updater --frequency 'daily' >> /var/log/cron.log 2>&1
 # 每周一凌晨2点执行一次 feed_updater_for_frequency 任务


### PR DESCRIPTION
## Summary

Fix Docker build/runtime issues that appear when building RSSBox from a Windows checkout.

## What Changed

- normalize `scripts/entrypoint.sh` to LF during Docker build to avoid CRLF-related startup failures
- stop installing `/etc/cron.d/rt_cron` via `crontab`, since files under `/etc/cron.d` already use system-cron format with username fields
- change the hourly cron expression from `*/60` to `0 * * * *` for clearer, more portable behavior

## Problem

When building from a Windows checkout, the container could fail to start because `entrypoint.sh` was copied with CRLF line endings. This caused errors such as:

- `exec /usr/local/bin/entrypoint.sh: no such file or directory`
- broken shell parsing due to `\r` line endings

In addition, the Docker build attempted to install `/etc/cron.d/rt_cron` with `crontab`, even though the file uses `/etc/cron.d` system-cron format with a username field.

## Verification

Verified locally by rebuilding and starting the Docker-based test instance successfully after these changes.