### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@
 
 ## Star历史图
 
-[![Star History Chart](https://api.star-history.com/svg?repos=versun/rssbox&type=Date)](https://star-history.com/#versun/rssbox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=versun/rssbox&type=Date)](https://star-history.dera.page/#versun/rssbox&Date)

--- a/README_EN.md
+++ b/README_EN.md
@@ -106,4 +106,4 @@ Thank you for your participation and support!
 
 ## Star History Chart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=versun/rssbox&type=Date)](https://star-history.com/#versun/rssbox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=versun/rssbox&type=Date)](https://star-history.dera.page/#versun/rssbox&Date)

--- a/docs/docs/index.en.md
+++ b/docs/docs/index.en.md
@@ -120,4 +120,4 @@ We welcome all forms of contribution! To contribute to rssbox, please follow the
 
 ## Star History Chart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=versun/rssbox&type=Date)](https://star-history.com/#versun/rssbox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=versun/rssbox&type=Date)](https://star-history.dera.page/#versun/rssbox&Date)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -119,4 +119,4 @@ summary: 让RSS管理更智能，让信息获取更高效
 
 ## Star历史图
 
-[![Star History Chart](https://api.star-history.com/svg?repos=versun/rssbox&type=Date)](https://star-history.com/#versun/rssbox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=versun/rssbox&type=Date)](https://star-history.dera.page/#versun/rssbox&Date)


### PR DESCRIPTION
The star history chart in the README and the localized documentation is currently broken due to GitHub stargazer API restrictions on the upstream service. This updates the chart image and links to a working alternative that does not require an API token. The change only affects the star history chart and leaves the badge untouched.